### PR TITLE
Fixed issue #195

### DIFF
--- a/window.js
+++ b/window.js
@@ -18,9 +18,8 @@ function createWindow () {
 
 app.whenReady().then(createWindow);
 
-app.on('window-all-closed', () => {
-  if (process.platform !== 'darwin')
-    app.quit();
+app.on('window-all-closed', function() {
+  app.quit();
 });
 
 app.on('activate', () => {


### PR DESCRIPTION
Remove the judgment of Darwin when event 'window-all-closed' occurs. 
This will close the application on macOS when the last window is closed.